### PR TITLE
Add to .profile not .bash_profile

### DIFF
--- a/keyring.sh
+++ b/keyring.sh
@@ -71,7 +71,7 @@ install-bashrc() {
     alias ssh-add=\"$SCRIPT ssh-add\"
 fi"
 
-    CODE_EXISTS=$(grep "$SCRIPT ssh-add" ~/.profile || echo)
+    CODE_EXISTS=$(grep "$SCRIPT ssh-add" ~/.profile || grep "$SCRIPT ssh-add" ~/.bash_profile || echo)
     if [ ! -z "$CODE_EXISTS" ]; then
         echo "It looks like the ssh-agent code is already in your ~/.profile file. Skipping."
     else

--- a/keyring.sh
+++ b/keyring.sh
@@ -21,7 +21,7 @@ install() {
     
     install-bashrc
     add-key ~/.ssh/id_rsa
-    PS1='$ ' source ~/.bash_profile
+    PS1='$ ' source ~/.profile
 }
 
 install_linux() {
@@ -71,19 +71,19 @@ install-bashrc() {
     alias ssh-add=\"$SCRIPT ssh-add\"
 fi"
 
-    CODE_EXISTS=$(grep "$SCRIPT ssh-add" ~/.bash_profile || echo)
+    CODE_EXISTS=$(grep "$SCRIPT ssh-add" ~/.profile || echo)
     if [ ! -z "$CODE_EXISTS" ]; then
-        echo "It looks like the ssh-agent code is already in your ~/.bash_profile file. Skipping."
+        echo "It looks like the ssh-agent code is already in your ~/.profile file. Skipping."
     else
         echo
-        echo "This code will be added to your ~/.bash_profile:"
+        echo "This code will be added to your ~/.profile:"
         echo
         echo "$CODE"
         echo
         echo -n "Do you want to proceed [Y/n]? "
         read ANSWER
         if [[ ! "$ANSWER" =~ ^[Nn]$ ]]; then
-            echo "$CODE" >> ~/.bash_profile
+            echo "$CODE" >> ~/.profile
         fi
     fi
     


### PR DESCRIPTION
So this works for zsh, fish etc. Not sure why we originally made it only go to .bash_profile.